### PR TITLE
In production, run with Unicorn instead of webrick

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,23 @@
+# config/unicorn.rb
+worker_processes Integer(ENV["WEB_CONCURRENCY"] || 3)
+timeout 28
+preload_app true
+
+before_fork do |server, worker|
+  Signal.trap 'TERM' do
+    puts 'Unicorn master intercepting TERM and sending myself QUIT instead'
+    Process.kill 'QUIT', Process.pid
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.connection.disconnect!
+end
+
+after_fork do |server, worker|
+  Signal.trap 'TERM' do
+    puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT'
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
Unicorn will allow for more concurrency.  Webrick is single-threaded blocking, and could get backed up behind Twilio API calls.
